### PR TITLE
Make AutoPku installable from both Claude Code and Codex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 !/LICENSE
 !/README.md
 !/skill.md
+!/codex/
+!/codex/autopku/
+!/codex/autopku/**
 !/images
 # 汇总报告（自动生成）
 通知摘要汇总.md

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ---
 ## 快速开始
 
-事先自行解决 claude code 安装
+本仓库现在同时支持 Claude Code 和 Codex 两种模式。
 
 ### 第一步：下载 Skill
 
@@ -20,7 +20,15 @@
 git clone https://github.com/ICUlizhi/AutoPku.git
 ```
 
-### 第二步：交给 Claude Code
+如果你是从自己的 fork 使用，也可以：
+
+```bash
+git clone git@github.com:187370/AutoPku.git
+```
+
+### 第二步：选择 Agent 运行模式
+
+#### 方式 A：Claude Code
 
 在 Claude Code 中加载 skill：
 
@@ -34,7 +42,17 @@ git clone https://github.com/ICUlizhi/AutoPku.git
 学号是 2200011111，密码是 xxx
 ```
 
-### 第三步：离开电脑，相信cc
+#### 方式 B：Codex
+
+如果你只是本地试跑，可以直接让 Codex 读取：
+
+```
+读取 AutoPku/codex/autopku/SKILL.md，并执行
+```
+
+如果你想把它安装成可复用的 Codex skill，安装路径使用仓库内的 `codex/autopku` 目录即可。
+
+### 第三步：离开电脑，相信 agent
 去拥抱北平难得的春天
 
 ![alt text](images/ccui.png)
@@ -58,9 +76,14 @@ git clone https://github.com/ICUlizhi/AutoPku.git
 ##  Introduction
 
 
-本项目基于 Claude Code 的实验性 Agent Team 功能实现。但我没有选择自建一套 Agent 系统，而是将全部领域逻辑（教学网登录 via pku3b、PDF 解析策略、LaTeX 渲染管线、教学网提交协议等）内嵌在一个 skill.md 文件中。原因是：
+本项目最初基于 Claude Code 的实验性 Agent Team 功能实现。现在仓库同时保留：
+
+- 根目录 `skill.md`：Claude Code 入口
+- `codex/autopku/SKILL.md`：Codex 入口
+
+我没有选择自建一套 Agent 系统，而是将全部领域逻辑（教学网登录 via pku3b、PDF 解析策略、LaTeX 渲染管线、教学网提交协议等）内嵌在 skill 文件中。原因是：
 - **由一体化 Agentic RL 训练出的 Claude Code，工具调用被蒸馏回了模型参数，且涌现出了人类炼丹师想不到的pattern, 其内置的能力远优于手工搭建的 Agent 框架**。
-- 与其维护一套需要单独配置 API key 的外部系统，不如直接利用每个人本地已配置好的 Claude Code 实例——它已经有了用户的 context，已经具备了执行环境，已经是高度自由的通用 agent。
+- 与其维护一套需要单独配置 API key 的外部系统，不如直接利用每个人本地已配置好的通用 coding agent 实例。
 
 
 ---
@@ -216,6 +239,5 @@ Team: autopku-team
 - 目前兼容的作业类型不够多，后期希望加载更多 skill 例如 pptx 绘制，欢迎提 pr. 
 
 ---
-
 
 

--- a/codex/autopku/SKILL.md
+++ b/codex/autopku/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: autopku
+description: Use when the user wants Codex to automate PKU coursework workflows with AutoPku, including syncing course notices, organizing assignments, and optionally completing a user-selected homework with confirmation before submission.
+---
+
+# AutoPku for Codex
+
+## Purpose
+
+This is the Codex entrypoint for the AutoPku project.
+
+- Claude Code users should use the repository root [skill.md](../../skill.md).
+- Codex users should use this file.
+
+## Use When
+
+- The user wants to pull current PKU course notices or assignments.
+- The user wants per-course folders with summaries and downloaded files.
+- The user wants help finishing a specific homework, but only after explicitly choosing the target assignment.
+
+## Safety Rules
+
+- Never auto-select the latest homework.
+- Never auto-submit without explicit confirmation of the exact course and assignment.
+- Do not echo the user's password back in summaries or logs.
+- Treat upstream Claude-specific config as reference material, not as a required Codex configuration step.
+
+## Default Workflow
+
+1. Read the repository root [skill.md](../../skill.md) when it is available in the checked-out repo. Use it as domain guidance for PKU-specific commands, parsing quirks, and pitfalls.
+2. Ask the user for student ID and password only when the task truly requires portal access.
+3. Check whether `pku3b` is installed. If not, install the correct release for the local machine instead of assuming the example URL is still current.
+4. Use a TTY-safe login flow such as `expect` for `pku3b init`.
+5. Fetch course and assignment data, normalize ANSI-heavy output, and save machine-readable intermediates under a task-specific work directory.
+6. For notice-sync mode:
+   - identify current-term courses
+   - create per-course directories
+   - download available materials
+   - generate one per-course summary plus an aggregate summary
+7. For homework mode:
+   - list candidate assignments for the chosen course
+   - require the user to confirm the exact assignment
+   - parse the homework source
+   - draft answers
+   - render deliverables
+   - submit only after explicit confirmation
+8. Verify generated files exist before reporting completion.
+
+## Codex-Specific Guidance
+
+- When parallel work helps, use Codex native subagents for bounded per-course or per-phase work instead of relying on Claude Agent Team wording.
+- Prefer a dedicated work directory such as `./autopku-work/` or a user-specified path instead of hardcoding `test/`.
+- If live command behavior differs from the repository notes, trust current command output and update working notes during execution.
+- If the request is only to install or inspect the skill, stop after setup verification.
+
+## Verification
+
+- Confirm required tools exist before execution.
+- Confirm login succeeded before fetching data.
+- Confirm expected files exist on disk after downloads or rendering.
+- Before any submission step, confirm the selected assignment matches the user's explicit choice.

--- a/codex/autopku/SKILL.md
+++ b/codex/autopku/SKILL.md
@@ -9,8 +9,9 @@ description: Use when the user wants Codex to automate PKU coursework workflows 
 
 This is the Codex entrypoint for the AutoPku project.
 
-- Claude Code users should use the repository root [skill.md](../../skill.md).
+- Claude Code users should use the repository root `skill.md`.
 - Codex users should use this file.
+- If this skill was installed standalone, use [references/upstream-skill.md](references/upstream-skill.md) as the bundled upstream reference.
 
 ## Use When
 
@@ -27,7 +28,7 @@ This is the Codex entrypoint for the AutoPku project.
 
 ## Default Workflow
 
-1. Read the repository root [skill.md](../../skill.md) when it is available in the checked-out repo. Use it as domain guidance for PKU-specific commands, parsing quirks, and pitfalls.
+1. Read the bundled reference [references/upstream-skill.md](references/upstream-skill.md). If the checked-out repository root `skill.md` is also available, prefer the newer copy as domain guidance for PKU-specific commands, parsing quirks, and pitfalls.
 2. Ask the user for student ID and password only when the task truly requires portal access.
 3. Check whether `pku3b` is installed. If not, install the correct release for the local machine instead of assuming the example URL is still current.
 4. Use a TTY-safe login flow such as `expect` for `pku3b init`.

--- a/codex/autopku/references/upstream-skill.md
+++ b/codex/autopku/references/upstream-skill.md
@@ -1,0 +1,28 @@
+---
+name: autopku
+description: 自动获取和整理北京大学课程通知，完成作业并提交
+---
+
+## 上游说明
+
+这个文件是仓库根目录 `skill.md` 的安装时参考副本，供 Codex 版 skill 在独立安装后继续读取领域规则和踩坑记录。
+
+- Claude Code 主入口仍然是仓库根目录 `skill.md`
+- Codex 主入口是 `codex/autopku/SKILL.md`
+
+## Claude 特定提示
+
+原始 `skill.md` 中包含 `.claude/settings.local.json`、`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` 等 Claude Code 特定配置。
+
+Codex 使用这个参考文件时：
+
+- 把这些内容视为上游背景说明
+- 不要把它们当成 Codex 的必需配置步骤
+- 保留其中关于 `pku3b`、`expect`、课程抓取、作业解析、提交流程的领域知识
+
+## 原始入口提示
+
+> Claude Code 入口。
+> 如果你使用 Codex，请改为读取 `codex/autopku/SKILL.md`。
+
+其余具体执行细节，请优先参考仓库根目录 `skill.md` 的最新版本；如果当前是独立安装的 Codex skill，则以本目录安装副本和实际命令输出为准。

--- a/skill.md
+++ b/skill.md
@@ -3,6 +3,9 @@ name: autopku
 description: 自动获取和整理北京大学课程通知，完成作业并提交
 ---
 
+> Claude Code 入口。
+> 如果你使用 Codex，请改为读取 `codex/autopku/SKILL.md`。
+
 ## 前置配置
 
 在执行此 skill 前，需要确保本地 `.claude/settings.local.json` 包含以下配置：


### PR DESCRIPTION
AutoPku previously exposed only the Claude-oriented root skill entrypoint. This change keeps that workflow intact while adding a Codex-specific skill directory and dual-mode documentation so a fork can serve both agent environments from one repository.

Constraint: Default macOS filesystems are case-insensitive, so root-level `skill.md` and `SKILL.md` cannot coexist safely
Rejected: Add root `SKILL.md` next to `skill.md` | path collision on common developer machines
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep Claude-specific entry behavior in `skill.md` and place future Codex assets under `codex/autopku/`
Tested: Reviewed git diff and repository layout; verified `.gitignore` tracks `codex/autopku/SKILL.md`
Not-tested: Live execution in Claude Code or Codex against PKU services