### PR TITLE
Make lecture note generation reproducible across runtimes

### DIFF
--- a/skill.md
+++ b/skill.md
@@ -194,7 +194,7 @@ chmod +x /tmp/pku3b_login.exp
 |------|------|------|
 | 同步通知 | `tasks/sync-notices.md` | 获取作业/公告，生成摘要，并行处理课程 |
 | 完成作业 | `tasks/do-homework.md` | 解析PDF→解答→渲染→询问用户→提交 |
-| 撰写笔记 | `tasks/write-notes.md` | 从课件提取数学核心，去除噪声 |
+| 撰写笔记 | `tasks/write-notes.md` | 标准 notes pipeline：每 PDF 一个 Writer Agent，生成 `notes/*.md`、`notes/README.md`，可选合成 PDF |
 
 ## Tool Skills 索引
 
@@ -278,6 +278,29 @@ test/
 └── 提交/                           # 最终提交文件
     └── Homework202605_answer.pdf
 ```
+
+### 撰写笔记输出
+
+AutoPku 的标准笔记 pipeline 由 `sub-skills/tasks/write-notes.md` 定义：
+
+```
+{course}/
+├── lectures/                         # 原始 PDF 课件，或用户指定的 PDF 目录
+├── notes/
+│   ├── {lecture_name}.md             # 每个 PDF 对应一篇 Writer Agent 笔记
+│   └── README.md                     # Coordinator 生成的课程索引
+└── pdf/                              # 可选：用户要求合成 PDF 时创建
+    ├── {course_name}课程笔记.typ
+    ├── {course_name}课程笔记.pdf
+    └── notes-template.typ
+```
+
+执行约定：
+- 每个 PDF 创建一个独立 Writer Agent 并行处理。
+- Writer Agent 按 `sub-skills/tools/pdf-reader.md` 的 PyMuPDF/pdfplumber 方案读取课件。
+- Writer Agent 只写自己的 `notes/{lecture_name}.md`，不得修改索引。
+- Coordinator 等全部 Writer Agent 完成后生成 `notes/README.md`。
+- 需要合成文档时，再由 Coordinator 使用 Pandoc + Typst/LaTeX 风格模板输出 PDF，并验证页数和首页文本。
 
 ## 安全规则
 

--- a/sub-skills/tasks/write-notes.md
+++ b/sub-skills/tasks/write-notes.md
@@ -1,13 +1,30 @@
 ---
 name: autopku-task-write-notes
-description: 读取课程slides，使用Agent Team撰写精简数学笔记，去除噪声内容
+description: Standard AutoPku notes pipeline: one PDF per writer agent, PDF text extraction via pdf-reader, per-lecture Markdown notes, README index, and optional polished PDF export.
 ---
 
 # 任务：撰写课程笔记
 
-## 前置询问（必须）
+本任务是 AutoPku 的标准笔记 pipeline。核心原则：
 
-在执行前，使用 `AskUserQuestion` 询问用户：
+- 每个课件 PDF 独立分配一个 Writer Agent 并行处理。
+- Writer Agent 必须按 `sub-skills/tools/pdf-reader.md` 的 PyMuPDF/pdfplumber 方案读取 PDF。
+- 每个 PDF 只产出一个单篇笔记：`notes/{lecture_name}.md`。
+- Coordinator 等全部 Writer Agent 完成后，再生成 `notes/README.md` 作为课程笔记索引。
+- 如用户要求合成 PDF，再用 Pandoc + Typst/LaTeX 风格模板从 `notes/` 生成排版文档。
+
+## 触发场景
+
+用户表达以下意图时使用本任务：
+
+- "给某门课写笔记"
+- "整理课件"
+- "把 PDF 课件整理成 notes"
+- "生成课程笔记 PDF"
+
+## 前置确认
+
+如果用户没有明确给出范围，询问最少必要问题：
 
 ```python
 AskUserQuestion({
@@ -23,188 +40,215 @@ AskUserQuestion({
         {
             "question": "笔记详细程度：",
             "options": [
-                {"label": "精简（只保留核心定义和定理）", "value": "minimal"},
-                {"label": "标准（包含证明思路）", "value": "standard"},
-                {"label": "详细（完整推导过程）", "value": "detailed"}
+                {"label": "精简（只保留核心定义、结论和考试点）", "value": "minimal"},
+                {"label": "标准（包含证明思路、关键机制和例子）", "value": "standard"},
+                {"label": "详细（完整推导、代码/实验步骤和扩展说明）", "value": "detailed"}
             ],
             "multiSelect": False
         },
         {
-            "question": "额外要求（多选）：",
+            "question": "是否需要最终合成 PDF 文档：",
             "options": [
-                {"label": "添加LaTeX公式编号", "value": "numbered_eq"},
-                {"label": "添加概念之间的关联图", "value": "concept_map"},
-                {"label": "添加例题（如有）", "value": "examples"},
-                {"label": "生成Anki卡片", "value": "anki"}
+                {"label": "需要", "value": "pdf"},
+                {"label": "暂不需要", "value": "markdown_only"}
             ],
-            "multiSelect": True
+            "multiSelect": False
         }
     ]
 })
 ```
 
-## 执行流程
+如果用户已经明确课程、PDF 目录或输出形式，直接执行，不重复询问。
 
-1. **发现课件**: 扫描 `lectures/` 目录，列出所有 PDF
-2. **用户确认**: 询问笔记范围和详细程度
-3. **并行处理**: 为每个 PDF 创建 agent，引用 `pdf-reader` 解析
-4. **汇总索引**: 生成 `notes/README.md` 索引文件
+## 标准目录约定
 
-## Agent 工作流
-
-### Coordinator
-
-```
-你是 Coordinator，协调笔记撰写任务。
-
-输入目录：{lectures_dir}
-输出目录：{notes_dir}
-
-任务列表：{pdf_list}
-
-执行：
-1. 为每个 PDF 并行创建 writer agent
-2. 收集所有 agent 完成报告
-3. 生成 notes/README.md 索引
-
-返回：
-- 处理了多少个 PDF
-- 生成了多少个笔记文件
-- 索引文件路径
+```text
+{course_dir}/
+├── lectures/                 # 推荐课件目录；也可使用用户指定 PDF 目录
+│   ├── 01-topic.pdf
+│   └── 02-topic.pdf
+├── notes/
+│   ├── 01-topic.md
+│   ├── 02-topic.md
+│   └── README.md
+└── pdf/                      # 仅在用户要求合成文档时创建
+    ├── {course_name}课程笔记.typ
+    ├── {course_name}课程笔记.pdf
+    └── notes-template.typ
 ```
 
-### Writer Agent（每个 PDF 一个）
+## Coordinator Pipeline
 
-```
-你是笔记撰写专家，从课件中提取数学核心内容。
+Coordinator 负责发现输入、创建 Writer Agent、收敛结果、生成索引和验证输出。
 
-输入：{pdf_path}
-输出：{notes_dir}/{lecture_name}.md
+1. **发现课件**
+   - 优先使用用户指定目录。
+   - 未指定时，在课程目录中依次查找 `lectures/`、`课件/`、`slides/`、`materials/`。
+   - 只处理 `.pdf` 文件，按文件名自然排序。
 
-## 引用工具
-引用: `sub-skills/tools/pdf-reader.md`
+2. **准备输出目录**
+   - 创建 `notes/`。
+   - 为每个 PDF 生成稳定文件名：保留课程顺序前缀，去掉不可用于文件名的字符，输出为 `notes/{lecture_name}.md`。
+   - 如目标文件已存在，除非用户要求覆盖，否则先读取并判断是否需要增量更新。
 
-使用 PyMuPDF 读取 PDF：
+3. **并行 Writer Agents**
+   - 为每个 PDF 创建一个 Writer Agent。
+   - 每个 Writer Agent 只拥有自己的 `{pdf_path}` 和 `{note_path}` 写入范围。
+   - Writer Agent 之间不能共享同一个输出文件，不能修改 `notes/README.md`。
+   - Codex 环境使用 native subagents；Claude/Kimi 环境使用各自 Agent Team；不支持并行时串行执行同一 Writer prompt。
+
+4. **生成索引**
+   - 等全部 Writer Agent 完成后，Coordinator 读取每个 note 的标题、摘要、关键概念。
+   - 生成或更新 `notes/README.md`，作为课程级入口。
+
+5. **可选 PDF 合成**
+   - 用户要求 PDF 时，使用 `notes/README.md` + 所有单篇 note 作为输入。
+   - 首选 Pandoc + Typst 生成轻量、好看的 LaTeX 风格 PDF；若环境已配置 XeLaTeX，也可使用 LaTeX 模板。
+   - 输出到 `pdf/{course_name}课程笔记.pdf`，不要覆盖原始课件 PDF。
+
+6. **验证**
+   - 检查每个 PDF 都有对应 `notes/{lecture_name}.md`。
+   - 检查 `notes/README.md` 链接的文件都存在。
+   - 如生成 PDF，检查 PDF 存在、页数大于 0，并抽取首页文本确认不是空白文档。
+
+## Writer Agent Prompt
+
+每个 PDF 使用以下模板创建独立 Writer Agent：
+
+````text
+你是 AutoPku 笔记 Writer Agent，负责把一个课程 PDF 整理成一篇可复习 Markdown 笔记。
+
+输入 PDF: {pdf_path}
+输出笔记: {note_path}
+详细程度: {detail_level}
+
+写入范围:
+- 只能创建或更新 {note_path}
+- 不能修改其他笔记
+- 不能修改 notes/README.md
+
+必须引用工具:
+- 阅读 sub-skills/tools/pdf-reader.md
+- 优先使用 PyMuPDF 读取全文
+- 遇到表格或 PyMuPDF 抽取质量差时，用 pdfplumber 补读对应页
+
+推荐读取代码:
 ```python
+from pathlib import Path
 import fitz
-doc = fitz.open("{pdf_path}")
-text = "\n\n".join([page.get_text() for page in doc])
-doc.close()
+
+pdf_path = Path("{pdf_path}")
+with fitz.open(pdf_path) as doc:
+    pages = [(i + 1, page.get_text("text")) for i, page in enumerate(doc)]
 ```
 
-## 内容筛选原则（重要）
+内容筛选:
+- 保留课程核心问题、定义、原理、机制、定理、算法、实验步骤、关键代码/命令、易错点。
+- 去除重复页眉页脚、课堂闲聊、纯装饰性图片说明、无助于复习的背景故事。
+- 对公式使用 LaTeX：行内 `$...$`，行间 `$$...$$`。
+- 对代码和命令使用 fenced code block。
+- 对无法可靠抽取的图表，标注页码并用一句话说明需要人工查看。
 
-### ✅ 保留内容
-- **Motivation**: 为什么要研究这个问题？核心问题是什么？
-- **定义**: 形式化定义、符号表示
-- **定理/命题**: 精确陈述，编号
-- **证明**: 关键证明步骤、核心技巧
-- **结论**: 主要结果、推论
-- **技术工具**: 关键引理、构造方法
-
-### ❌ 去除内容
-- **历史背景**: 谁发明的、发展历程
-- **故事/轶事**: 麻雀、哲学家轶事等
-- **日常用例**: 用自然语言解释的例子（除非是必要的直觉）
-- **复杂无关概念**: 用更复杂的概念解释简单概念
-- **重复性内容**: 多处出现的相同解释
-- **装饰性语言**: "让我们来看看"、"有趣的是"等
-
-## 笔记格式
-
+输出格式:
 ```markdown
-# {Lecture 标题}
+# {lecture_title}
 
-## 核心问题/Motivation
-- 本节要解决的中心问题
-- 与前文的关系（如有）
+> 来源：{pdf_filename}
+> 页数：{page_count}
 
-## 定义
+## 本讲主线
+- ...
 
-### 定义 X.X （概念名）
-**陈述**: 形式化定义
+## 核心概念
 
-**符号**: $...$
-
-## 定理与命题
-
-### 定理 X.X （定理名）
-**陈述**: 精确数学陈述
-
-**证明**:
-1. 关键步骤...
-2. 核心技巧...
-3. ...
-
-**直观**（可选，一句话）: ...
-
-## 技术工具/引理
-
-### 引理 X.X
+### {concept}
 ...
 
-## 结论
-- 本节主要结果总结
-- 关键公式/事实
+## 关键机制 / 推导 / 算法
+...
 
-## 记号速查
-| 符号 | 含义 |
-|-----|------|
-| $...$ | ... |
+## 例题 / 实验 / 命令
+...
+
+## 易错点
+- ...
+
+## 速查
+| 项 | 内容 |
+|----|------|
+| ... | ... |
+
+## 仍需人工确认
+- 第 X 页：...
 ```
 
-## 约束
-- 笔记必须可渲染（标准 Markdown）
-- 数学公式使用 LaTeX（$...$ 行内，$$...$$ 行间）
-- 保留原始课件的结构层次（章节编号）
-- 如某节无数学内容（纯故事/历史），标注"本节为导言/背景，略"
-
-返回：
-- 处理页数
-- 提取的定义数、定理数
+完成报告:
+- PDF 页数
 - 输出文件路径
-- 备注（如有难以处理的内容）
-```
+- 主要章节数
+- 无法抽取或需要人工确认的页码
+````
 
-## 输出文件
+## README 索引格式
 
-### 单个笔记文件
-`notes/{lecture_name}.md`
-
-### 索引文件
-`notes/README.md`
+Coordinator 生成 `notes/README.md`：
 
 ```markdown
-# 逻辑导论 笔记索引
+# {course_name} 笔记索引
 
 生成时间: {timestamp}
+课件数量: {pdf_count}
+笔记数量: {note_count}
 
-## 课程概览
-{课程简介}
+## 阅读顺序
 
-## 章节索引
+| 序号 | 课件 | 笔记 | 核心内容 |
+|-----|------|------|----------|
+| 1 | 01-topic.pdf | [01-topic.md](01-topic.md) | ... |
 
-| 序号 | 标题 | 核心内容 | 文件 |
-|-----|------|---------|------|
-| 1 | 导言 | ... | [01.导言.md](01.导言.md) |
-| 2 | 一只麻雀... | ... | [02.一只麻雀...](...) |
-| ... | ... | ... | ... |
+## 课程主线
+- ...
 
-## 关键概念图谱
-{概念之间的依赖关系}
+## 关键概念地图
+- A -> B -> C
 
-## 公式速查
-{重要公式列表}
+## 复习速查
+- ...
+
+## 生成说明
+- 每个 PDF 由独立 Writer Agent 处理。
+- PDF 文本读取采用 `sub-skills/tools/pdf-reader.md` 中的 PyMuPDF/pdfplumber 方案。
+```
+
+## PDF 合成规范
+
+当用户要求"组成一个 PDF 文档"或类似意图时执行：
+
+1. 确认可用工具：`pandoc`、`typst`；如果用户明确要求 LaTeX，再检查 `xelatex` 或 `lualatex`。
+2. 在 `pdf/` 下创建排版模板，例如 `notes-template.typ` 或 `notes-template.tex`。
+3. 使用 `notes/README.md` 和所有 `notes/*.md` 生成单一源文件。
+4. 编译输出 `pdf/{course_name}课程笔记.pdf`。
+5. 验证 PDF 页数和首页文本，避免生成空白 PDF。
+
+示例命令：
+
+```bash
+pandoc notes/README.md notes/*.md \
+  --from markdown+smart \
+  --to typst \
+  --standalone \
+  --toc --toc-depth=2 \
+  --metadata title="{course_name}课程笔记" \
+  -V template="notes-template.typ" \
+  -o "pdf/{course_name}课程笔记.typ"
+
+typst compile "pdf/{course_name}课程笔记.typ" "pdf/{course_name}课程笔记.pdf"
 ```
 
 ## 使用示例
 
 ```bash
 skill: autopku notes 逻辑导论
-```
-
-或在其他目录使用：
-
-```bash
-skill: autopku notes /path/to/lectures /path/to/notes
+skill: autopku notes /path/to/course/lectures /path/to/course/notes
+skill: autopku notes 操作系统 --pdf
 ```


### PR DESCRIPTION
The notes workflow now records the pipeline validated in the local operating-system course run: one PDF maps to one isolated writer agent, the coordinator owns the index, and optional document export happens only after Markdown outputs are complete.

Constraint: Must support Codex native subagents while keeping Claude/Kimi Agent Team guidance usable.
Rejected: Leave the flow as a loose prompt example | it did not preserve the one-PDF-one-note contract or final README/PDF verification.
Confidence: high
Scope-risk: narrow
Directive: Do not let writer agents modify notes/README.md; keep coordinator-only ownership for aggregation.
Tested: git diff --check; searched diff for credential-like strings
Not-tested: End-to-end rerun from the committed skill after push