### PR TITLE
feat: add Codex SKILL entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ git clone git@github.com:187370/AutoPku.git
 如果你只是本地试跑，可以直接让 Codex 读取：
 
 ```
-读取 AutoPku/codex/autopku/SKILL.md，并执行
+读取 AutoPku/SKILL.md，并执行
 ```
 
-如果你想把它安装成可复用的 Codex skill，安装路径使用仓库内的 `codex/autopku` 目录即可。
+如果你想把它安装成可复用的 Codex skill，直接安装仓库根目录即可；Codex 入口文件就是根目录的 `SKILL.md`。
 
 ### 第三步：离开电脑，相信 agent
 去拥抱北平难得的春天
@@ -81,7 +81,7 @@ git clone git@github.com:187370/AutoPku.git
 本项目最初基于 Claude Code 的实验性 Agent Team 功能实现。现在仓库同时保留：
 
 - 根目录 `skill.md`：Claude Code 入口
-- `codex/autopku/SKILL.md`：Codex 入口
+- 根目录 `SKILL.md`：Codex 入口
 
 我没有选择自建一套 Agent 系统，而是将全部领域逻辑（教学网登录 via pku3b、PDF 解析策略、LaTeX 渲染管线、教学网提交协议等）内嵌在 skill 文件中。原因是：
 - **由一体化 Agentic RL 训练出的 Claude Code，工具调用被蒸馏回了模型参数，且涌现出了人类炼丹师想不到的pattern, 其内置的能力远优于手工搭建的 Agent 框架**。
@@ -241,5 +241,3 @@ Team: autopku-team
 - 目前兼容的作业类型不够多，后期希望加载更多 skill 例如 pptx 绘制，欢迎提 pr. 
 
 ---
-
-

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: autopku
+description: Use when the user wants Codex to automate PKU coursework workflows with AutoPku, including syncing course notices, organizing assignments, writing notes from course materials, and optionally completing a user-selected homework with confirmation before submission.
+---
+
+# AutoPku for Codex
+
+## Purpose
+
+This is the Codex entrypoint for the AutoPku repository.
+
+- Claude Code users should use [skill.md](skill.md).
+- Codex users should use this file.
+- Treat [skill.md](skill.md) as the upstream domain reference and `sub-skills/` as the detailed workflow library.
+
+## Use When
+
+- The user wants to pull current PKU course notices or assignments.
+- The user wants per-course folders with summaries and downloaded files.
+- The user wants help finishing a specific homework, but only after explicitly choosing the target assignment.
+- The user wants notes distilled from PKU course slides or PDFs.
+
+## Safety Rules
+
+- Never auto-select the latest homework.
+- Never auto-submit without explicit confirmation of the exact course and assignment.
+- Do not echo the user's password back in summaries or logs.
+- When the repository reference says `AskUserQuestion`, ask the user directly in chat instead of assuming a Codex-only tool exists.
+- Treat Claude-specific config as reference material, not as a required Codex configuration step.
+
+## Default Workflow
+
+1. Read [skill.md](skill.md) first, then load only the relevant files under `sub-skills/` for the task at hand.
+2. Ask the user for student ID and password only when the task truly requires portal access.
+3. Check whether `pku3b` is installed. If not, install the correct release for the local machine instead of assuming the example URL is still current.
+4. Use a TTY-safe login flow such as `expect` for `pku3b init`.
+5. Fetch course and assignment data, normalize ANSI-heavy output, and save machine-readable intermediates under a task-specific work directory.
+6. For notice-sync mode:
+   - identify current-term courses
+   - create per-course directories
+   - download available materials
+   - generate one per-course summary plus an aggregate summary
+7. For homework mode:
+   - list candidate assignments for the chosen course
+   - require the user to confirm the exact assignment
+   - parse the homework source
+   - draft answers
+   - render deliverables
+   - submit only after explicit confirmation
+8. For note-writing mode:
+   - ask which course materials or lecture range to process
+   - confirm desired detail level
+   - extract the mathematical core from slides or PDFs
+   - generate Markdown notes and render PDF only when requested or clearly useful
+9. Verify generated files exist before reporting completion.
+
+## Codex-Specific Guidance
+
+- When parallel work helps, use Codex native subagents for bounded per-course or per-phase work instead of Claude Agent Team wording.
+- When spawning Codex subagents, use model `gpt-5.3-codex` by default unless the user explicitly requests a different model.
+- Prefer a dedicated work directory such as `./autopku-work/` or a user-specified path instead of hardcoding `test/`.
+- If live command behavior differs from the repository notes, trust current command output and update working notes during execution.
+- If the request is only to install or inspect the skill, stop after setup verification.
+- Prefer `pku3b` from `PATH`, but if Homebrew is installed on Apple Silicon, explicitly check `/opt/homebrew/bin/pku3b` as a common location.
+- The standard local config path on macOS is `~/Library/Application Support/org.sshwy.pku3b/cfg.toml`; confirm it exists before attempting login flows that assume stored credentials.
+- If `pku3b s -d major show` or similar syllabus commands fail with a redirect or auth error, treat them as optional enrichment rather than a hard prerequisite and continue with assignment-driven course discovery from `pku3b a ls` or `pku3b a ls --all-term`.
+
+## Verification
+
+- Confirm required tools exist before execution.
+- Confirm login succeeded before fetching data.
+- Confirm expected files exist on disk after downloads or rendering.
+- Before any submission step, confirm the selected assignment matches the user's explicit choice.
+
+## Validation Notes
+
+- Verified against a local install at `/opt/homebrew/bin/pku3b`.
+- Verified that `pku3b a ls` can return live assignment data with an existing config.
+- Observed that `pku3b s -d major show` may fail with `302 Found` on some accounts, so the workflow must not depend exclusively on that command.


### PR DESCRIPTION
## Summary
- add a root `SKILL.md` so the repository is directly usable as a Codex skill
- document Codex-specific safety and workflow guidance while reusing the existing `skill.md` and `sub-skills/`
- fix README instructions that currently point to a non-existent `codex/autopku/SKILL.md`

## Why
The README already says the repo supports Codex, but the documented Codex path does not exist in the repository today. This PR makes the Codex entrypoint real and aligns the setup instructions with the actual repo structure.

## Notes
- kept the existing root `skill.md` as the Claude Code entrypoint
- used a root `SKILL.md` for Codex so the repo can be installed directly as a Codex skill
- no runtime code changed; this is a documentation and packaging update only
