### PR TITLE
fix(write-paper): 去除Word文档中的python-docx生成痕迹

### DIFF
--- a/sub-skills/tasks/write-paper.md
+++ b/sub-skills/tasks/write-paper.md
@@ -291,6 +291,17 @@ for ref in references:
     run._element.rPr.rFonts.set(qn('w:eastAsia'), '宋体')
 
 doc.save(f'{course}/论文/paper.docx')
+
+# 修改文档属性，去除 python-docx 生成痕迹
+from datetime import datetime, timezone
+props = doc.core_properties
+props.author = name                    # 设置为学生姓名
+props.last_modified_by = name
+props.title = title                    # 设置为论文题目
+props.subject = f'{course}课程论文'
+props.created = datetime.now(timezone.utc)
+props.modified = datetime.now(timezone.utc)
+doc.save(f'{course}/论文/paper.docx')
 ```
 
 ### 6. 输出与用户确认
@@ -329,6 +340,7 @@ doc.save(f'{course}/论文/paper.docx')
 | graphviz 未安装 | 无 `dot` 命令 | `brew install graphviz` 或退化为 matplotlib 绘制 |
 | 目录未生成 | 只编译了一次 xelatex | 需编译两次以生成 `toc` 文件 |
 | Word 中公式显示差 | python-docx 不支持 LaTeX 公式 | 简单公式用纯文本，复杂公式建议用 LaTeX 模式 |
+| Word 文档属性暴露生成方式 | python-docx 默认作者为 "python-docx" | 生成后修改 core_properties，将 author 设为学生姓名 |
 
 ## 使用示例
 


### PR DESCRIPTION
   生成docx后自动修改文档属性（author/title/created等），避免在文档元数据中暴露python-docx生成方式。

   ## 背景

   python-docx生成的文档默认作者为python-docx，创建时间为2013-12-23，容易被识别出生成方式。

   ## 改动内容

   - 在Word模式的doc.save()后增加属性修改步骤