### PR TITLE
fix(pku3b): upgrade to v0.14.0 to resolve TLS handshake failure

### DIFF
--- a/sub-skills/tools/pku3b-setup.md
+++ b/sub-skills/tools/pku3b-setup.md
@@ -13,20 +13,26 @@ which pku3b 2>/dev/null || echo "NOT_FOUND"
 
 ## 安装
 
+### 推荐版本
+
+**重要**: 使用 **v0.14.0+** 以避免 TLS 握手错误。v0.11.0 存在已知的连接问题。
+
 ### macOS Apple Silicon
 ```bash
 cd /tmp
-curl -LO "https://github.com/sshwy/pku3b/releases/download/0.11.0/pku3b-0.11.0-aarch64-apple-darwin.tar.gz"
-tar -xzf pku3b-0.11.0-aarch64-apple-darwin.tar.gz
-chmod +x pku3b-0.11.0-aarch64-apple-darwin/pku3b
-ln -sf pku3b-0.11.0-aarch64-apple-darwin/pku3b pku3b
-./pku3b --version
+curl -LO "https://github.com/sshwy/pku3b/releases/download/0.14.0/pku3b-0.14.0-aarch64-apple-darwin.tar.gz"
+tar -xzf pku3b-0.14.0-aarch64-apple-darwin.tar.gz
+chmod +x pku3b-0.14.0-aarch64-apple-darwin/pku3b
+ln -sf /tmp/pku3b-0.14.0-aarch64-apple-darwin/pku3b /tmp/pku3b
+/tmp/pku3b --version
 ```
 
 ### 其他平台
 从 [sshwy/pku3b releases](https://github.com/sshwy/pku3b/releases) 下载对应版本。
 
-> **版本说明**: v0.11.0+ 支持公告 (`ann`) 和课表 (`ct`) 功能
+> **版本说明**: 
+> - v0.14.0+: 修复 TLS 握手问题，推荐使用
+> - v0.11.0+: 支持公告 (`ann`) 和课表 (`ct`) 功能，但存在连接问题
 
 ## 登录
 
@@ -89,6 +95,32 @@ echo "" > /tmp/pku3b_login.exp
 ```
 
 ## 踩坑记录
+
+### TLS 握手失败（v0.11.0）
+
+**问题**: 
+```
+Error: login to blackboard: `hyper` client error: received fatal alert: HandshakeFailure
+```
+
+**原因**: pku3b v0.11.0 的 Rust HTTP 客户端（hyper）与 PKU 教学网的 TLS 配置不兼容。
+
+**解决方案**: 升级到 v0.14.0+
+```bash
+cd /tmp
+curl -LO "https://github.com/sshwy/pku3b/releases/download/0.14.0/pku3b-0.14.0-aarch64-apple-darwin.tar.gz"
+tar -xzf pku3b-0.14.0-aarch64-apple-darwin.tar.gz
+chmod +x pku3b-0.14.0-aarch64-apple-darwin/pku3b
+ln -sf /tmp/pku3b-0.14.0-aarch64-apple-darwin/pku3b /tmp/pku3b
+/tmp/pku3b --version  # 应显示 0.14.0
+```
+
+验证修复：
+```bash
+/tmp/pku3b a ls 2>&1 | head -5  # 应正常显示作业列表
+```
+
+### 其他已知问题
 
 - `pku3b init` 需要交互式输入，直接管道输入不工作
 - `pku3b auth status/login` 命令不存在，正确命令是 `pku3b init`


### PR DESCRIPTION
# Fix: Upgrade pku3b to v0.14.0 to resolve TLS handshake failure

## 问题描述

使用 pku3b v0.11.0 时，连接 PKU 教学网会出现 TLS 握手失败错误：

```
Error: login to blackboard: `hyper` client error: client error (Connect): 
client error (Connect): system error: received fatal alert: HandshakeFailure
```

### 影响范围
- 无法获取作业列表 (`pku3b a ls`)
- 无法获取公告 (`pku3b ann ls`)
- 所有需要连接教学网的操作都会失败

### 根本原因
pku3b v0.11.0 使用的 Rust HTTP 客户端（hyper）与 PKU 教学网的 TLS 配置不兼容。

## 解决方案

升级到 **pku3b v0.14.0**，该版本包含 TLS 兼容性修复。

## 更改内容

### 文件修改
- `sub-skills/tools/pku3b-setup.md`

### 主要变更
1. **更新推荐版本**：从 v0.11.0 升级到 v0.14.0
2. **更新安装命令**：所有安装示例使用 v0.14.0
3. **添加故障排查章节**：详细记录问题、原因和解决步骤
4. **版本说明更新**：标注各版本的已知问题

## 验证步骤

更新后验证连接正常：

```bash
# 1. 检查版本
/tmp/pku3b --version  
# 输出应为: pku3b 0.14.0

# 2. 测试连接
/tmp/pku3b a ls 2>&1 | head -5
# 应正常显示作业列表，而不是 TLS 错误

# 3. 测试课程内容
/tmp/pku3b cc ls 2>&1 | head -10
# 应正常显示课程内容列表
```

## 测试结果

✅ pku3b v0.14.0 成功连接教学网  
✅ 可以正常获取作业列表  
✅ 可以正常获取课表信息  
✅ 可以正常使用 course-content 功能下载课件  

## 相关信息

- **上游项目**: https://github.com/sshwy/pku3b
- **Release Notes**: https://github.com/sshwy/pku3b/releases/tag/0.14.0
- **Build Info**: 
  - Build time: 2026-05-29 06:10:27 +00:00
  - Rust version: 1.96.0

## Checklist

- [x] 更新文档中的版本号
- [x] 添加问题排查指南
- [x] 本地测试通过
- [x] 提交信息符合规范

## 备注

建议所有使用 AutoPku 的用户尽快升级到 v0.14.0，以避免连接问题。v0.11.0 的 TLS 问题可能会影响所有依赖教学网 API 的功能。
